### PR TITLE
refactor: complete redesign of get_entries tool with typed parameters

### DIFF
--- a/example-new-api.js
+++ b/example-new-api.js
@@ -1,0 +1,245 @@
+// Example of the NEW get_entries API with direct typed parameters
+// NO MORE JSON.stringify!
+
+const exampleUsage = {
+  // ======================================
+  // SIMPLE QUERY - Just get all entries
+  // ======================================
+  simple: {
+    name: 'get_entries',
+    arguments: {
+      contentTypeUid: 'api::article.article'
+    }
+  },
+
+  // ======================================
+  // WITH FILTERS - Direct object, no stringify!
+  // ======================================
+  withFilters: {
+    name: 'get_entries',
+    arguments: {
+      contentTypeUid: 'api::article.article',
+      filters: {
+        title: { $contains: 'JavaScript' },
+        published_at: { $notNull: true }
+      }
+    }
+  },
+
+  // ======================================
+  // COMPLEX FILTERS with $and, $or
+  // ======================================
+  complexFilters: {
+    name: 'get_entries',
+    arguments: {
+      contentTypeUid: 'api::product.product',
+      filters: {
+        $or: [
+          { price: { $lt: 100 } },
+          { 
+            $and: [
+              { category: { $eq: 'electronics' } },
+              { featured: { $eq: true } }
+            ]
+          }
+        ]
+      }
+    }
+  },
+
+  // ======================================
+  // WITH PAGINATION - Direct object
+  // ======================================
+  withPagination: {
+    name: 'get_entries',
+    arguments: {
+      contentTypeUid: 'api::post.post',
+      pagination: {
+        page: 2,
+        pageSize: 20
+      }
+    }
+  },
+
+  // ======================================
+  // WITH POPULATION - String or object
+  // ======================================
+  populateAll: {
+    name: 'get_entries',
+    arguments: {
+      contentTypeUid: 'api::article.article',
+      populate: '*'  // Populate everything
+    }
+  },
+
+  populateSpecific: {
+    name: 'get_entries',
+    arguments: {
+      contentTypeUid: 'api::article.article',
+      populate: ['author', 'categories', 'cover']  // Array of fields
+    }
+  },
+
+  populateNested: {
+    name: 'get_entries',
+    arguments: {
+      contentTypeUid: 'api::article.article',
+      populate: {
+        author: {
+          populate: ['avatar', 'bio']
+        },
+        categories: {
+          fields: ['name', 'slug']
+        },
+        sections: {
+          populate: '*'  // Required for dynamic zones
+        }
+      }
+    }
+  },
+
+  // ======================================
+  // WITH FIELD SELECTION
+  // ======================================
+  withFields: {
+    name: 'get_entries',
+    arguments: {
+      contentTypeUid: 'api::article.article',
+      fields: ['title', 'slug', 'publishedAt']
+    }
+  },
+
+  // ======================================
+  // WITH SORTING - String or array
+  // ======================================
+  withSort: {
+    name: 'get_entries',
+    arguments: {
+      contentTypeUid: 'api::article.article',
+      sort: 'createdAt:DESC'  // Single sort
+    }
+  },
+
+  withMultiSort: {
+    name: 'get_entries',
+    arguments: {
+      contentTypeUid: 'api::article.article',
+      sort: ['featured:DESC', 'createdAt:DESC']  // Multiple sorts
+    }
+  },
+
+  // ======================================
+  // WITH LOCALE
+  // ======================================
+  withLocale: {
+    name: 'get_entries',
+    arguments: {
+      contentTypeUid: 'api::page.page',
+      locale: 'fr'  // Get French version
+    }
+  },
+
+  allLocales: {
+    name: 'get_entries',
+    arguments: {
+      contentTypeUid: 'api::page.page',
+      locale: 'all'  // Get all locales
+    }
+  },
+
+  // ======================================
+  // WITH STATUS (Draft & Publish)
+  // ======================================
+  publishedOnly: {
+    name: 'get_entries',
+    arguments: {
+      contentTypeUid: 'api::article.article',
+      status: 'published'
+    }
+  },
+
+  draftsOnly: {
+    name: 'get_entries',
+    arguments: {
+      contentTypeUid: 'api::article.article',
+      status: 'draft'
+    }
+  },
+
+  // ======================================
+  // COMPLETE EXAMPLE - All parameters
+  // ======================================
+  complete: {
+    name: 'get_entries',
+    arguments: {
+      contentTypeUid: 'api::article.article',
+      
+      // Filters - direct object
+      filters: {
+        $and: [
+          { category: { $in: ['tech', 'science'] } },
+          { featured: { $eq: true } },
+          { publishedAt: { $gte: '2024-01-01' } }
+        ]
+      },
+      
+      // Population - complex nested
+      populate: {
+        author: {
+          fields: ['name', 'email'],
+          populate: {
+            avatar: {
+              fields: ['url', 'alternativeText']
+            }
+          }
+        },
+        categories: '*',
+        tags: {
+          sort: 'name:ASC'
+        }
+      },
+      
+      // Field selection
+      fields: ['title', 'slug', 'excerpt', 'publishedAt'],
+      
+      // Pagination
+      pagination: {
+        page: 1,
+        pageSize: 10
+      },
+      
+      // Sorting
+      sort: ['featured:DESC', 'publishedAt:DESC'],
+      
+      // Locale
+      locale: 'en',
+      
+      // Status
+      status: 'published'
+    }
+  },
+
+  // ======================================
+  // DOCUMENT ID FILTER (Special case)
+  // ======================================
+  byDocumentId: {
+    name: 'get_entries',
+    arguments: {
+      contentTypeUid: 'api::article.article',
+      documentId: 'abc123def456',  // Gets combined with filters using $and
+      locale: 'en'
+    }
+  }
+};
+
+console.log('New get_entries API Examples:');
+console.log('==============================');
+console.log('No more JSON.stringify! All parameters are now direct, typed objects.');
+console.log('');
+console.log('Benefits:');
+console.log('- ✅ Full TypeScript/IDE support');
+console.log('- ✅ Better error messages');
+console.log('- ✅ Cleaner, more readable code');
+console.log('- ✅ Direct alignment with Strapi REST API');
+console.log('');
+console.log('Old format with options: JSON.stringify() is NO LONGER SUPPORTED!');

--- a/tests/documented-errors.test.ts
+++ b/tests/documented-errors.test.ts
@@ -295,7 +295,7 @@ describe('Documented Strapi MCP Errors', () => {
           contentTypeUid: 'api::page.page',
           documentId: testEntryId,
           locale: 'en',
-          options: JSON.stringify({ populate: '*' })
+          populate: '*'
         }
       });
 
@@ -327,13 +327,11 @@ describe('Documented Strapi MCP Errors', () => {
           contentTypeUid: 'api::page.page',
           documentId: testEntryId,
           locale: 'en',
-          options: JSON.stringify({ 
-            populate: { 
-              sections: { 
-                populate: '*' 
-              } 
+          populate: { 
+            sections: { 
+              populate: '*' 
             } 
-          })
+          }
         }
       });
 

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -139,13 +139,11 @@ describe('Strapi MCP Server', () => {
         name: 'get_entries',
         arguments: {
           contentTypeUid: 'api::project.project',
-          options: JSON.stringify({
-            filters: {
-              name: {
-                $contains: 'Test'
-              }
+          filters: {
+            name: {
+              $contains: 'Test'
             }
-          })
+          }
         }
       });
 
@@ -409,7 +407,7 @@ describe('Strapi MCP Server', () => {
         arguments: {
           contentTypeUid: 'api::project.project',
           documentId: created.documentId,
-          options: JSON.stringify({ status: 'published' })
+          status: 'published'
         }
       });
       const published = JSON.parse(getResult.content[0].text);
@@ -475,9 +473,7 @@ describe('Strapi MCP Server', () => {
         arguments: {
           contentTypeUid: 'api::project.project',
           documentId: created.documentId,
-          options: JSON.stringify({
-            status: 'draft'
-          })
+          status: 'draft'
         }
       });
       const draftEntries = JSON.parse(draftResult.content[0].text);

--- a/tests/partial-update.test.ts
+++ b/tests/partial-update.test.ts
@@ -73,7 +73,7 @@ describe('Partial Update Functionality', () => {
         arguments: {
           contentTypeUid: 'api::page.page',
           documentId: testDocumentId,
-          options: JSON.stringify({ populate: '*' })
+          populate: '*'
         }
       });
 
@@ -114,7 +114,7 @@ describe('Partial Update Functionality', () => {
         arguments: {
           contentTypeUid: 'api::page.page',
           documentId: testDocumentId,
-          options: JSON.stringify({ populate: '*' })
+          populate: '*'
         }
       });
 
@@ -164,7 +164,7 @@ describe('Partial Update Functionality', () => {
         arguments: {
           contentTypeUid: 'api::page.page',
           documentId: testDocumentId,
-          options: JSON.stringify({ populate: '*' })
+          populate: '*'
         }
       });
 

--- a/tests/section-management-regression.test.ts
+++ b/tests/section-management-regression.test.ts
@@ -86,7 +86,7 @@ describe('Section Management - Status Field Regression', () => {
         arguments: {
           contentTypeUid: 'api::page.page',
           documentId: testDocumentId,
-          options: JSON.stringify({ populate: '*' })
+          populate: '*'
         }
       });
       
@@ -124,7 +124,7 @@ describe('Section Management - Status Field Regression', () => {
         arguments: {
           contentTypeUid: 'api::page.page',
           documentId: testDocumentId,
-          options: JSON.stringify({ populate: '*' })
+          populate: '*'
         }
       });
       
@@ -176,7 +176,7 @@ describe('Section Management - Status Field Regression', () => {
         arguments: {
           contentTypeUid: 'api::page.page',
           documentId: testDocumentId,
-          options: JSON.stringify({ populate: '*' })
+          populate: '*'
         }
       });
       
@@ -200,7 +200,7 @@ describe('Section Management - Status Field Regression', () => {
         arguments: {
           contentTypeUid: 'api::page.page',
           documentId: testDocumentId,
-          options: JSON.stringify({ populate: '*' })
+          populate: '*'
         }
       });
       
@@ -242,7 +242,7 @@ describe('Section Management - Status Field Regression', () => {
         arguments: {
           contentTypeUid: 'api::page.page',
           documentId: testDocumentId,
-          options: JSON.stringify({ populate: '*' })
+          populate: '*'
         }
       });
       

--- a/tests/section-management.test.ts
+++ b/tests/section-management.test.ts
@@ -70,7 +70,7 @@ describe('Section Management Tools', () => {
           arguments: {
             contentTypeUid: 'api::page.page',
             documentId: testDocumentId,
-            options: JSON.stringify({ populate: '*' })
+            populate: '*'
           }
         });
 
@@ -107,7 +107,7 @@ describe('Section Management Tools', () => {
           arguments: {
             contentTypeUid: 'api::page.page',
             documentId: testDocumentId,
-            options: JSON.stringify({ populate: '*' })
+            populate: '*'
           }
         });
 
@@ -170,7 +170,7 @@ describe('Section Management Tools', () => {
           arguments: {
             contentTypeUid: 'api::page.page',
             documentId: testDocumentId,
-            options: JSON.stringify({ populate: '*' })
+            populate: '*'
           }
         });
 
@@ -216,7 +216,7 @@ describe('Section Management Tools', () => {
           arguments: {
             contentTypeUid: 'api::page.page',
             documentId: testDocumentId,
-            options: JSON.stringify({ populate: '*' })
+            populate: '*'
           }
         });
 
@@ -243,7 +243,7 @@ describe('Section Management Tools', () => {
           arguments: {
             contentTypeUid: 'api::page.page',
             documentId: testDocumentId,
-            options: JSON.stringify({ populate: '*' })
+            populate: '*'
           }
         });
 
@@ -280,7 +280,7 @@ describe('Section Management Tools', () => {
           arguments: {
             contentTypeUid: 'api::page.page',
             documentId: testDocumentId,
-            options: JSON.stringify({ populate: '*' })
+            populate: '*'
           }
         });
 
@@ -310,7 +310,7 @@ describe('Section Management Tools', () => {
           arguments: {
             contentTypeUid: 'api::page.page',
             documentId: testDocumentId,
-            options: JSON.stringify({ populate: '*' })
+            populate: '*'
           }
         });
 

--- a/tests/strapi5-filters.test.ts
+++ b/tests/strapi5-filters.test.ts
@@ -20,7 +20,7 @@ describe('Strapi 5 Filter Operators', () => {
       name: 'get_entries',
       arguments: {
         contentTypeUid: 'api::project.project',
-        options: JSON.stringify({ pagination: { pageSize: 100 } })
+        pagination: { pageSize: 100 }
       }
     });
     const existingProjects = JSON.parse(existingResult.content[0].text);
@@ -96,9 +96,7 @@ describe('Strapi 5 Filter Operators', () => {
       name: 'get_entries',
       arguments: {
         contentTypeUid: 'api::project.project',
-        options: JSON.stringify({
-          pagination: { pageSize: 100 }
-        })
+        pagination: { pageSize: 100 }
       }
     });
     const allProjects = JSON.parse(allResult.content[0].text);
@@ -118,15 +116,13 @@ describe('Strapi 5 Filter Operators', () => {
       name: 'get_entries',
       arguments: {
         contentTypeUid: 'api::project.project',
-        options: JSON.stringify({
-          filters: {
-            $and: [{
-              name: {
-                $contains: 'Project'
-              }
-            }]
-          }
-        })
+        filters: {
+          $and: [{
+            name: {
+              $contains: 'Project'
+            }
+          }]
+        }
       }
     });
 
@@ -153,15 +149,13 @@ describe('Strapi 5 Filter Operators', () => {
       name: 'get_entries', 
       arguments: {
         contentTypeUid: 'api::project.project',
-        options: JSON.stringify({
-          filters: {
-            $and: [{
-              name: {
-                $in: [testProjectNames[0], testProjectNames[2]] // Alpha Project, Gamma Development
-              }
-            }]
-          }
-        })
+        filters: {
+          $and: [{
+            name: {
+              $in: [testProjectNames[0], testProjectNames[2]] // Alpha Project, Gamma Development
+            }
+          }]
+        }
       }
     });
 

--- a/tests/strapi5-pagination.test.ts
+++ b/tests/strapi5-pagination.test.ts
@@ -14,12 +14,10 @@ describe('Strapi 5 Pagination', () => {
       name: 'get_entries',
       arguments: {
         contentTypeUid: 'api::project.project',
-        options: JSON.stringify({
-          pagination: {
-            page: 1,
-            pageSize: 5
-          }
-        })
+        pagination: {
+          page: 1,
+          pageSize: 5
+        }
       }
     });
 

--- a/tests/tools/content-management-unit.test.ts
+++ b/tests/tools/content-management-unit.test.ts
@@ -74,7 +74,7 @@ describe('Content Management Tools - Unit Tests', () => {
 
       const result = await getTool().execute({
         contentTypeUid: 'api::article.article',
-        options: JSON.stringify({ filters: { title: 'test' } })
+        filters: { title: 'test' }
       });
 
       expect(mockClient.getEntries).toHaveBeenCalledWith('api::article.article', {
@@ -83,11 +83,13 @@ describe('Content Management Tools - Unit Tests', () => {
       expect(result).toEqual(mockResponse);
     });
 
-    it('should handle invalid JSON gracefully', async () => {
-      await expect(getTool().execute({
+    it('should reject invalid filter types', async () => {
+      // The schema should reject non-object filters
+      const tool = getTool();
+      await expect(tool.inputSchema.parseAsync({
         contentTypeUid: 'api::article.article',
-        options: 'invalid json'
-      })).rejects.toThrow('Invalid options JSON');
+        filters: 'invalid string instead of object'
+      })).rejects.toThrow();
     });
 
     it('should handle empty options', async () => {

--- a/tests/tools/content-management.test.ts
+++ b/tests/tools/content-management.test.ts
@@ -342,19 +342,21 @@ describe('Content Management Tools', () => {
       const tool = tools.find(t => t.name === 'get_entries')!;
       const result = await tool.execute({ 
         contentTypeUid: 'api::article.article',
-        options: JSON.stringify(options)
+        filters: options.filters,
+        pagination: options.pagination,
+        sort: options.sort
       });
 
       expect(mockClient.getEntries).toHaveBeenCalledWith('api::article.article', options);
       expect(result).toEqual(mockEntries);
     });
 
-    it('should handle invalid JSON options', async () => {
+    it('should reject invalid filter types', async () => {
       const tool = tools.find(t => t.name === 'get_entries')!;
       
       await expect(
-        tool.execute({ contentTypeUid: 'api::article.article', options: 'invalid json' })
-      ).rejects.toThrow('Invalid options JSON');
+        tool.inputSchema.parseAsync({ contentTypeUid: 'api::article.article', filters: 'invalid should be object' })
+      ).rejects.toThrow();
     });
   });
 


### PR DESCRIPTION
BREAKING CHANGE: Removed JSON string 'options' parameter completely

- Added proper Zod schemas for filters, populate, pagination, sort, and fields
- All parameters are now top-level typed arguments instead of JSON strings
- Added .strict() validation to reject unknown parameters (no backward compatibility)
- Updated all 219 tests to use the new parameter format

New API structure:
- filters: Direct object with full Strapi operator support ($eq, $in, $contains, etc.)
- populate: String ('*'), array, or complex nested object
- pagination: Object with page/pageSize properties
- fields: Array of field names to select
- sort: String or array of sort criteria
- locale: Direct string parameter
- status: Enum for 'published' or 'draft'

This change eliminates JSON.stringify() usage, provides full TypeScript type safety, and aligns directly with Strapi's REST API structure.

🤖 Generated with [Claude Code](https://claude.ai/code)